### PR TITLE
wps_QDM

### DIFF
--- a/chickadee/io.py
+++ b/chickadee/io.py
@@ -1,5 +1,5 @@
 from pywps import LiteralInput, ComplexInput, FORMATS
-
+from datetime import date
 import logging
 
 
@@ -48,12 +48,10 @@ num_cores = LiteralInput(
     data_type="positiveInteger",
 )
 
-end_date = (
-    LiteralInput(
-        "end_date",
-        "End Date",
-        abstract="Defines the end of the calibration period",
-        default=date(2005, 12, 31),
-        data_type="date",
-    ),
+end_date = LiteralInput(
+    "end_date",
+    "End Date",
+    abstract="Defines the end of the calibration period",
+    default=date(2005, 12, 31),
+    data_type="date",
 )

--- a/chickadee/io.py
+++ b/chickadee/io.py
@@ -47,3 +47,13 @@ num_cores = LiteralInput(
     allowed_values=[1, 2, 3, 4],
     data_type="positiveInteger",
 )
+
+end_date = (
+    LiteralInput(
+        "end_date",
+        "End Date",
+        abstract="Defines the end of the calibration period",
+        default=date(2005, 12, 31),
+        data_type="date",
+    ),
+)

--- a/chickadee/processes/__init__.py
+++ b/chickadee/processes/__init__.py
@@ -1,7 +1,9 @@
 from .wps_CI import CI
 from .wps_bccaq import BCCAQ
+from .wps_QDM import QDM
 
 processes = [
     CI(),
     BCCAQ(),
+    QDM(),
 ]

--- a/chickadee/processes/wps_CI.py
+++ b/chickadee/processes/wps_CI.py
@@ -1,4 +1,4 @@
-from pywps import Process, ComplexInput, ComplexOutput, LiteralInput, FORMATS
+from pywps import Process
 from pywps.app.Common import Metadata
 
 from wps_tools.utils import log_handler

--- a/chickadee/processes/wps_CI.py
+++ b/chickadee/processes/wps_CI.py
@@ -3,7 +3,7 @@ from pywps.app.Common import Metadata
 
 from wps_tools.utils import log_handler
 from wps_tools.io import log_level, nc_output
-from chickadee.utils import logger, get_package, collect_common_args
+from chickadee.utils import logger, get_package, collect_args
 from chickadee.io import gcm_file, obs_file, varname, out_file, num_cores
 
 
@@ -49,7 +49,7 @@ class CI(Process):
             output_file,
             num_cores,
             loglevel,
-        ) = collect_common_args(request)
+        ) = collect_args(request)
         log_handler(
             self,
             response,

--- a/chickadee/processes/wps_CI.py
+++ b/chickadee/processes/wps_CI.py
@@ -34,6 +34,9 @@ class CI(Process):
             metadata=[
                 Metadata("NetCDF processing"),
                 Metadata("Climate Data Operations"),
+                Metadata("PyWPS", "https://pywps.org/"),
+                Metadata("Birdhouse", "http://bird-house.github.io/"),
+                Metadata("PyWPS Demo", "https://pywps-demo.readthedocs.io/en/latest/"),
             ],
             inputs=inputs,
             outputs=outputs,
@@ -42,14 +45,9 @@ class CI(Process):
         )
 
     def _handler(self, request, response):
-        (
-            gcm_file,
-            obs_file,
-            varname,
-            output_file,
-            num_cores,
-            loglevel,
-        ) = collect_args(request)
+        (gcm_file, obs_file, varname, output_file, num_cores, loglevel,) = collect_args(
+            request
+        )
         log_handler(
             self,
             response,

--- a/chickadee/processes/wps_CI.py
+++ b/chickadee/processes/wps_CI.py
@@ -45,9 +45,14 @@ class CI(Process):
         )
 
     def _handler(self, request, response):
-        (gcm_file, obs_file, varname, output_file, num_cores, loglevel,) = collect_args(
-            request
-        )
+        (
+            gcm_file,
+            obs_file,
+            varname,
+            output_file,
+            num_cores,
+            loglevel,
+        ) = collect_args(request)
         log_handler(
             self,
             response,

--- a/chickadee/processes/wps_QDM.py
+++ b/chickadee/processes/wps_QDM.py
@@ -98,7 +98,7 @@ class QDM(Process):
             process_step="set_end_date",
         )
         set_end = set_r_options()
-        set_end(end_date)
+        set_end(str(end_date))
 
         log_handler(
             self,

--- a/chickadee/processes/wps_QDM.py
+++ b/chickadee/processes/wps_QDM.py
@@ -6,7 +6,7 @@ from wps_tools.io import log_level, nc_output
 from chickadee.utils import (
     logger,
     get_package,
-    collect_common_args,
+    collect_args,
     set_r_options,
     common_status_percentage,
 )
@@ -54,7 +54,7 @@ class QDM(Process):
             num_cores,
             end_date,
             loglevel,
-        ) = collect_common_args(request)
+        ) = collect_args(request)
 
         log_handler(
             self,

--- a/chickadee/processes/wps_QDM.py
+++ b/chickadee/processes/wps_QDM.py
@@ -14,8 +14,9 @@ from chickadee.io import gcm_file, obs_file, varname, out_file, num_cores, end_d
 
 class QDM(Process):
     def __init__(self):
-        self.status_percentage_steps = common_status_percentage.update(
-            {"get_ClimDown": 5, "parallelization": 10, "set_end_date": 15}
+        self.status_percentage_steps = dict(
+            common_status_percentage,
+            **{"get_ClimDown": 5, "parallelization": 10, "set_end_date": 15},
         )
         inputs = [
             gcm_file,

--- a/chickadee/processes/wps_QDM.py
+++ b/chickadee/processes/wps_QDM.py
@@ -1,6 +1,5 @@
 from pywps import Process
 from pywps.app.Common import Metadata
-from datetime import date
 from wps_tools.utils import log_handler
 from wps_tools.io import log_level, nc_output
 from chickadee.utils import (

--- a/chickadee/processes/wps_QDM.py
+++ b/chickadee/processes/wps_QDM.py
@@ -4,7 +4,7 @@ from datetime import date
 from wps_tools.utils import log_handler
 from wps_tools.io import log_level, nc_output
 from chickadee.utils import logger, get_package, collect_common_args, set_r_options
-from chickadee.io import gcm_file, obs_file, varname, out_file, num_cores
+from chickadee.io import gcm_file, obs_file, varname, out_file, num_cores, end_date
 
 
 class QDM(Process):
@@ -21,13 +21,7 @@ class QDM(Process):
             varname,
             out_file,
             num_cores,
-            LiteralInput(
-                "end_date",
-                "End Date",
-                abstract="Defines the end of the calibration period",
-                default=date(2005, 12, 31),
-                data_type="date",
-            ),
+            end_date,
             log_level,
         ]
 

--- a/chickadee/processes/wps_QDM.py
+++ b/chickadee/processes/wps_QDM.py
@@ -91,7 +91,7 @@ class QDM(Process):
         set_end = set_r_options()
         set_end(end_date)
 
-        climdown.qdm_netcdf_wrapper(gcm_file, obs_file, output_file, varname)
+        climdown.qdm_netcdf_wrapper(obs_file, gcm_file, output_file, varname)
 
         # stop parallelization
         doPar.stopImplicitCluster()

--- a/chickadee/processes/wps_QDM.py
+++ b/chickadee/processes/wps_QDM.py
@@ -6,7 +6,7 @@ from chickadee.utils import (
     logger,
     get_package,
     collect_args,
-    set_r_options,
+    set_end_date,
     common_status_percentage,
 )
 from chickadee.io import gcm_file, obs_file, varname, out_file, num_cores, end_date
@@ -88,7 +88,7 @@ class QDM(Process):
         doPar = get_package("doParallel")
         doPar.registerDoParallel(cores=num_cores)
 
-        # Set R options
+        # Set R option 'calibration.end'
         log_handler(
             self,
             response,
@@ -97,8 +97,7 @@ class QDM(Process):
             log_level=loglevel,
             process_step="set_end_date",
         )
-        set_end = set_r_options()
-        set_end(str(end_date))
+        set_end_date(end_date)
 
         log_handler(
             self,

--- a/chickadee/processes/wps_QDM.py
+++ b/chickadee/processes/wps_QDM.py
@@ -48,10 +48,6 @@ class QDM(Process):
             status_supported=True,
         )
 
-    def collect_args(self, request):
-        end_date = str(request.inputs["end_date"][0].data)
-        return end_date
-
     def _handler(self, request, response):
         (
             gcm_file,
@@ -59,9 +55,9 @@ class QDM(Process):
             varname,
             output_file,
             num_cores,
+            end_date,
             loglevel,
         ) = collect_common_args(request)
-        end_date = self.collect_args(request)
 
         log_handler(
             self,

--- a/chickadee/processes/wps_QDM.py
+++ b/chickadee/processes/wps_QDM.py
@@ -16,7 +16,7 @@ from chickadee.io import gcm_file, obs_file, varname, out_file, num_cores, end_d
 class QDM(Process):
     def __init__(self):
         self.status_percentage_steps = common_status_percentage.update(
-            {"parallelization": 5, "set_end_date": 10, "process": 15}
+            {"get_ClimDown": 5, "parallelization": 10, "set_end_date": 15}
         )
         inputs = [
             gcm_file,
@@ -65,6 +65,15 @@ class QDM(Process):
             process_step="start",
         )
 
+        # Get ClimDown
+        log_handler(
+            self,
+            response,
+            "Importing R package 'ClimDown'",
+            logger,
+            log_level=loglevel,
+            process_step="get_ClimDown",
+        )
         climdown = get_package("ClimDown")
 
         # Set parallelization
@@ -88,7 +97,6 @@ class QDM(Process):
             log_level=loglevel,
             process_step="set_end_date",
         )
-
         set_end = set_r_options()
         set_end(end_date)
 
@@ -100,7 +108,6 @@ class QDM(Process):
             log_level=loglevel,
             process_step="process",
         )
-
         climdown.qdm_netcdf_wrapper(obs_file, gcm_file, output_file, varname)
 
         # stop parallelization
@@ -114,7 +121,6 @@ class QDM(Process):
             log_level=loglevel,
             process_step="build_output",
         )
-
         response.outputs["output"].file = output_file
 
         log_handler(
@@ -125,5 +131,4 @@ class QDM(Process):
             log_level=loglevel,
             process_step="complete",
         )
-
         return response

--- a/chickadee/processes/wps_QDM.py
+++ b/chickadee/processes/wps_QDM.py
@@ -38,6 +38,9 @@ class QDM(Process):
             metadata=[
                 Metadata("NetCDF processing"),
                 Metadata("Climate Data Operations"),
+                Metadata("PyWPS", "https://pywps.org/"),
+                Metadata("Birdhouse", "http://bird-house.github.io/"),
+                Metadata("PyWPS Demo", "https://pywps-demo.readthedocs.io/en/latest/"),
             ],
             inputs=inputs,
             outputs=outputs,

--- a/chickadee/processes/wps_QDM.py
+++ b/chickadee/processes/wps_QDM.py
@@ -1,0 +1,119 @@
+from pywps import Process, LiteralInput
+from pywps.app.Common import Metadata
+from datetime import date
+from wps_tools.utils import log_handler
+from wps_tools.io import log_level, nc_output
+from chickadee.utils import logger, get_package, collect_common_args, set_r_options
+from chickadee.io import gcm_file, obs_file, varname, out_file, num_cores
+
+
+class QDM(Process):
+    def __init__(self):
+        self.status_percentage_steps = {
+            "start": 0,
+            "process": 10,
+            "build_output": 95,
+            "complete": 100,
+        }
+        inputs = [
+            gcm_file,
+            obs_file,
+            varname,
+            out_file,
+            num_cores,
+            LiteralInput(
+                "end_date",
+                "End Date",
+                abstract="Defines the end of the calibration period",
+                default=date(2005, 12, 31),
+                data_type="date",
+            ),
+            log_level,
+        ]
+
+        outputs = [nc_output]
+
+        super(QDM, self).__init__(
+            self._handler,
+            identifier="qdm",
+            title="QDM",
+            abstract="High-level wrapper for Quantile Delta Mapping (QDM)",
+            metadata=[
+                Metadata("NetCDF processing"),
+                Metadata("Climate Data Operations"),
+            ],
+            inputs=inputs,
+            outputs=outputs,
+            store_supported=True,
+            status_supported=True,
+        )
+
+    def collect_args(self, request):
+        end_date = str(request.inputs["end_date"][0].data)
+        return end_date
+
+    def _handler(self, request, response):
+        (
+            gcm_file,
+            obs_file,
+            varname,
+            output_file,
+            num_cores,
+            loglevel,
+        ) = collect_common_args(request)
+        end_date = self.collect_args(request)
+
+        log_handler(
+            self,
+            response,
+            "Starting Process",
+            logger,
+            log_level=loglevel,
+            process_step="start",
+        )
+
+        climdown = get_package("ClimDown")
+
+        log_handler(
+            self,
+            response,
+            "Processing QDM",
+            logger,
+            log_level=loglevel,
+            process_step="process",
+        )
+
+        # Set parallelization
+        doPar = get_package("doParallel")
+        doPar.registerDoParallel(cores=num_cores)
+
+        # Set R options
+        set_end = set_r_options()
+        set_end(end_date)
+
+        climdown.qdm_netcdf_wrapper(gcm_file, obs_file, output_file, varname)
+
+        # stop parallelization
+        doPar.stopImplicitCluster()
+
+        log_handler(
+            self,
+            response,
+            "Building final output",
+            logger,
+            log_level=loglevel,
+            process_step="build_output",
+        )
+
+        response.outputs["output"].file = output_file
+
+        log_handler(
+            self,
+            response,
+            "Process Complete",
+            logger,
+            log_level=loglevel,
+            process_step="complete",
+        )
+
+        return response

--- a/chickadee/processes/wps_bccaq.py
+++ b/chickadee/processes/wps_bccaq.py
@@ -7,7 +7,7 @@ from netCDF4 import Dataset
 
 from wps_tools.utils import log_handler
 from wps_tools.io import log_level, nc_output
-from chickadee.utils import logger, set_r_options, get_package, collect_common_args
+from chickadee.utils import logger, set_r_options, get_package, collect_args
 from chickadee.io import gcm_file, obs_file, varname, out_file, num_cores, end_date
 
 
@@ -73,7 +73,7 @@ class BCCAQ(Process):
             num_cores,
             end_date,
             loglevel,
-        ) = collect_common_args(request)
+        ) = collect_args(request)
         os.path.join(self.workdir, out_file)
 
         log_handler(

--- a/chickadee/processes/wps_bccaq.py
+++ b/chickadee/processes/wps_bccaq.py
@@ -6,7 +6,7 @@ from netCDF4 import Dataset
 
 from wps_tools.utils import log_handler
 from wps_tools.io import log_level, nc_output
-from chickadee.utils import logger, set_r_options, get_package, collect_args
+from chickadee.utils import logger, set_end_date, get_package, collect_args
 from chickadee.io import gcm_file, obs_file, varname, out_file, num_cores, end_date
 
 
@@ -88,9 +88,8 @@ class BCCAQ(Process):
         doPar = get_package("doParallel")
         doPar.registerDoParallel(cores=num_cores)
 
-        # Set R options
-        set_end = set_r_options()
-        set_end(str(end_date))
+        # Set R options 'calibration.end'
+        set_end_date(end_date)
 
         # Run ClimDown
         climdown = get_package("ClimDown")

--- a/chickadee/processes/wps_bccaq.py
+++ b/chickadee/processes/wps_bccaq.py
@@ -1,14 +1,14 @@
 import os
 import re
 from datetime import date
-from pywps import Process, ComplexOutput, ComplexInput, LiteralInput, FORMATS
+from pywps import Process
 from pywps.app.Common import Metadata
 from netCDF4 import Dataset
 
 from wps_tools.utils import log_handler
 from wps_tools.io import log_level, nc_output
 from chickadee.utils import logger, set_r_options, get_package, collect_common_args
-from chickadee.io import gcm_file, obs_file, varname, out_file, num_cores
+from chickadee.io import gcm_file, obs_file, varname, out_file, num_cores, end_date
 
 
 class BCCAQ(Process):
@@ -30,13 +30,7 @@ class BCCAQ(Process):
             varname,
             out_file,
             num_cores,
-            LiteralInput(
-                "end_date",
-                "End Date",
-                abstract="Defines the end of the calibration period",
-                default=date(2005, 12, 31),
-                data_type="date",
-            ),
+            end_date,
             log_level,
         ]
 

--- a/chickadee/processes/wps_bccaq.py
+++ b/chickadee/processes/wps_bccaq.py
@@ -90,7 +90,7 @@ class BCCAQ(Process):
 
         # Set R options
         set_end = set_r_options()
-        set_end(end_date)
+        set_end(str(end_date))
 
         # Run ClimDown
         climdown = get_package("ClimDown")

--- a/chickadee/processes/wps_bccaq.py
+++ b/chickadee/processes/wps_bccaq.py
@@ -1,6 +1,5 @@
 import os
 import re
-from datetime import date
 from pywps import Process
 from pywps.app.Common import Metadata
 from netCDF4 import Dataset

--- a/chickadee/processes/wps_bccaq.py
+++ b/chickadee/processes/wps_bccaq.py
@@ -60,10 +60,6 @@ class BCCAQ(Process):
             status_supported=True,
         )
 
-    def collect_args(self, request):
-        end_date = str(request.inputs["end_date"][0].data)
-        return end_date
-
     def _handler(self, request, response):
         loglevel = request.inputs["loglevel"][0].data
         log_handler(
@@ -81,9 +77,9 @@ class BCCAQ(Process):
             varname,
             out_file,
             num_cores,
+            end_date,
             loglevel,
         ) = collect_common_args(request)
-        end_date = self.collect_args(request)
         os.path.join(self.workdir, out_file)
 
         log_handler(

--- a/chickadee/utils.py
+++ b/chickadee/utils.py
@@ -30,20 +30,20 @@ def get_package(package):
         raise ProcessError(f"R package, {package}, is not installed")
 
 
-def collect_common_args(request):
-    return_args = [
-        request.inputs["gcm_file"][0].file,
-        request.inputs["obs_file"][0].file,
-        request.inputs["varname"][0].data,
-        request.inputs["out_file"][0].data,
-        request.inputs["num_cores"][0].data,
-    ]
-    if "end_date" in request.inputs.keys():
-        return_args.append(str(request.inputs["end_date"][0].data))
-    return_args.append(request.inputs["loglevel"][0].data)
+def collect_args(request):
+    args = OrderedDict()
+    for k in request.inputs.keys():
+        if "data_type" in vars(request.inputs[k][0]).keys():
+            # LiteralData
+            args[request.inputs[k][0].identifier] = request.inputs[k][0].data
+        elif vars(request.inputs[k][0])["_url"] != None:
+            # OPeNDAP
+            args[request.inputs[k][0].identifier] = request.inputs[k][0].url
+        elif vars(request.inputs[k][0])["_file"] != None:
+            # Local files
+            args[request.inputs[k][0].identifier] = request.inputs[k][0].file
 
-    print(return_args)
-    return tuple(return_args)
+    return tuple(args.values())
 
 
 def set_r_options():

--- a/chickadee/utils.py
+++ b/chickadee/utils.py
@@ -15,6 +15,13 @@ handler = logging.StreamHandler()
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
+common_status_percentage = {
+    "start": 0,
+    "process": 10,
+    "build_output": 95,
+    "complete": 100,
+}
+
 
 def get_package(package):
     if isinstalled(package):

--- a/chickadee/utils.py
+++ b/chickadee/utils.py
@@ -24,14 +24,19 @@ def get_package(package):
 
 
 def collect_common_args(request):
-    gcm_file = request.inputs["gcm_file"][0].file
-    obs_file = request.inputs["obs_file"][0].file
-    varname = request.inputs["varname"][0].data
-    output_file = request.inputs["out_file"][0].data
-    num_cores = request.inputs["num_cores"][0].data
-    loglevel = request.inputs["loglevel"][0].data
+    return_args = [
+        request.inputs["gcm_file"][0].file,
+        request.inputs["obs_file"][0].file,
+        request.inputs["varname"][0].data,
+        request.inputs["out_file"][0].data,
+        request.inputs["num_cores"][0].data,
+    ]
+    if "end_date" in request.inputs.keys():
+        return_args.append(str(request.inputs["end_date"][0].data))
+    return_args.append(request.inputs["loglevel"][0].data)
 
-    return gcm_file, obs_file, varname, output_file, num_cores, loglevel
+    print(return_args)
+    return tuple(return_args)
 
 
 def set_r_options():

--- a/chickadee/utils.py
+++ b/chickadee/utils.py
@@ -17,7 +17,7 @@ logger.addHandler(handler)
 
 common_status_percentage = {
     "start": 0,
-    "process": 10,
+    "process": 20,
     "build_output": 95,
     "complete": 100,
 }

--- a/chickadee/utils.py
+++ b/chickadee/utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from rpy2 import robjects
 from rpy2.robjects.packages import isinstalled, importr
 from pywps.app.exceptions import ProcessError
@@ -38,7 +39,7 @@ def collect_args(request):
         elif vars(request.inputs[k][0])["_url"] != None:
             # OPeNDAP
             args[request.inputs[k][0].identifier] = request.inputs[k][0].url
-        elif vars(request.inputs[k][0])["_file"] != None:
+        elif os.path.isfile(request.inputs[k][0].file):
             # Local files
             args[request.inputs[k][0].identifier] = request.inputs[k][0].file
 

--- a/chickadee/utils.py
+++ b/chickadee/utils.py
@@ -1,7 +1,6 @@
 import logging
 from rpy2 import robjects
 from rpy2.robjects.packages import isinstalled, importr
-from rpy2.robjects.vectors import StrVector
 from pywps.app.exceptions import ProcessError
 from collections import OrderedDict
 
@@ -46,7 +45,7 @@ def collect_args(request):
     return tuple(args.values())
 
 
-def set_r_options():
+def set_end_date(end_date):
     robjects.r(
         """
     set_end_date <-function(end_date){
@@ -56,4 +55,6 @@ def set_r_options():
     }
     """
     )
-    return robjects.r["set_end_date"]
+
+    robjects.r["set_end_date"](str(end_date))
+    return

--- a/dev-component/wps.cfg
+++ b/dev-component/wps.cfg
@@ -1,5 +1,7 @@
 [server]
 outputurl = http://docker-dev03.pcic.uvic.ca:30102/outputs
+maxrequestsize = 65gb
+maxsingleinputsize = 200mb
 
 [logging]
 level = DEBUG

--- a/docs/source/notebooks/wps_QDM_demo.ipynb
+++ b/docs/source/notebooks/wps_QDM_demo.ipynb
@@ -1,0 +1,188 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# wps_QDM\n",
+    "\n",
+    "#### wps_QDM is a process that runs the [qdm.netcdf.wrapper](https://cran.r-project.org/web/packages/ClimDown/ClimDown.pdf#page=7) function of [ClimDown](https://cran.r-project.org/web/packages/ClimDown/index.html) package. To get started, first instatiate the client. Here, the client will try to connect to a remote chickadee instance using the url parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from birdy import WPSClient\n",
+    "from wps_tools.testing import get_target_url\n",
+    "from pkg_resources import resource_filename\n",
+    "from wps_tools.utils import copy_http_content\n",
+    "from tempfile import NamedTemporaryFile\n",
+    "from netCDF4 import Dataset\n",
+    "from datetime import date\n",
+    "\n",
+    "# Ensure we are in the working directory with access to the data\n",
+    "while os.path.basename(os.getcwd()) != \"chickadee\":\n",
+    "    os.chdir('../')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using chickadee on https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/chickadee/wps\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "url = get_target_url(\"chickadee\")\n",
+    "print(f\"Using chickadee on {url}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chickadee = WPSClient(\"http://localhost:5004/wps\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Help for individual processes can be diplayed using the ? command (ex. bird.process?)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m\n",
+       "\u001b[0mchickadee\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mqdm\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mgcm_file\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mobs_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mvarname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mnum_cores\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'4'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mend_date\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdatetime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m2005\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m12\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m31\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mout_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "High-level wrapper for Quantile Delta Mapping (QDM)\n",
+       "\n",
+       "Parameters\n",
+       "----------\n",
+       "gcm_file : ComplexData:mimetype:`application/x-netcdf`, :mimetype:`application/x-ogc-dods`\n",
+       "    Filename of GCM simulations\n",
+       "obs_file : ComplexData:mimetype:`application/x-netcdf`, :mimetype:`application/x-ogc-dods`\n",
+       "    Filename of high-res gridded historical observations\n",
+       "varname : string\n",
+       "    Name of the NetCDF variable to downscale (e.g. 'tasmax')\n",
+       "out_file : string\n",
+       "    Filename to create with the climate imprint outputs\n",
+       "num_cores : {'1', '2', '3', '4'}positiveInteger\n",
+       "    The number of cores to use for parallel execution\n",
+       "end_date : date\n",
+       "    Defines the end of the calibration period\n",
+       "loglevel : {'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET'}string\n",
+       "    Logging level\n",
+       "\n",
+       "Returns\n",
+       "-------\n",
+       "output : ComplexData:mimetype:`application/x-netcdf`\n",
+       "    Output Netcdf File\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Desktop/chickadee/</home/sangwonl/Desktop/chickadee/venv/lib/python3.7/site-packages/birdy/client/base.py-2>\n",
+       "\u001b[0;31mType:\u001b[0m      method\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "chickadee.qdm?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### We can use the docstring to ensure we provide the appropriate parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with NamedTemporaryFile(suffix=\".nc\", prefix=\"output_\", dir=\"/tmp\", delete=True) as out_file:\n",
+    "    output = chickadee.qdm(\n",
+    "        gcm_file = resource_filename(\"tests\", \"/data/CI_expected_output.nc\"),\n",
+    "        obs_file = resource_filename(\"tests\", \"/data/tiny_obs.nc\"),\n",
+    "        out_file = out_file.name,\n",
+    "        varname = \"tasmax\",\n",
+    "        num_cores = 2,\n",
+    "        end_date = date(1972, 12, 31),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Once the process has completed we can extract the results and ensure it is what we expected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with NamedTemporaryFile(suffix=\".nc\", prefix=\"tmp_copy\", dir=\"/tmp\", delete=True) as tmp_file:\n",
+    "    output_data = Dataset(copy_http_content(output.get()[0], tmp_file))\n",
+    "    expected_data = Dataset(resource_filename(\"tests\", \"/data/QDM_expected_output.nc\"))\n",
+    "    for key, value in expected_data.dimensions.items():\n",
+    "        assert str(output_data.dimensions[key]) == str(value)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/notebooks/wps_QDM_demo.ipynb
+++ b/docs/source/notebooks/wps_QDM_demo.ipynb
@@ -54,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chickadee = WPSClient(\"url\")"
+    "chickadee = WPSClient(url)"
    ]
   },
   {

--- a/docs/source/notebooks/wps_QDM_demo.ipynb
+++ b/docs/source/notebooks/wps_QDM_demo.ipynb
@@ -54,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chickadee = WPSClient(\"http://localhost:5004/wps\")"
+    "chickadee = WPSClient(\"url\")"
    ]
   },
   {

--- a/docs/source/notebooks/wps_bccaq_demo.ipynb
+++ b/docs/source/notebooks/wps_bccaq_demo.ipynb
@@ -39,7 +39,15 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using chickadee on https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/chickadee/wps\n"
+     ]
+    }
+   ],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "url = get_target_url(\"chickadee\")\n",
@@ -74,12 +82,12 @@
        "\u001b[0;31mSignature:\u001b[0m\n",
        "\u001b[0mchickadee\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbccaq\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mgcm_file\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mobs_file\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mvar\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mout_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mend_date\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdatetime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m2005\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m12\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m31\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mobs_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mvarname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mnum_cores\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'4'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mend_date\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdatetime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m2005\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m12\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m31\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mout_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Full statistical downscaling of coarse scale global climate model (GCM) output to a fine spatial resolution\n",
@@ -90,22 +98,22 @@
        "    Filename of GCM simulations\n",
        "obs_file : ComplexData:mimetype:`application/x-netcdf`, :mimetype:`application/x-ogc-dods`\n",
        "    Filename of high-res gridded historical observations\n",
-       "var : {'tasmax', 'tasmin', 'pr'}string\n",
-       "    Name of the NetCDF variable to downscale\n",
-       "end_date : date\n",
-       "    Defines the end of the calibration period\n",
+       "varname : string\n",
+       "    Name of the NetCDF variable to downscale (e.g. 'tasmax')\n",
        "out_file : string\n",
-       "    Path to output file\n",
+       "    Filename to create with the climate imprint outputs\n",
        "num_cores : {'1', '2', '3', '4'}positiveInteger\n",
        "    The number of cores to use for parallel execution\n",
+       "end_date : date\n",
+       "    Defines the end of the calibration period\n",
        "loglevel : {'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET'}string\n",
        "    Logging level\n",
        "\n",
        "Returns\n",
        "-------\n",
        "output : ComplexData:mimetype:`application/x-netcdf`\n",
-       "    output netCDF file\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/code/birds/chickadee/</tmp/chickadee-venv/lib/python3.8/site-packages/birdy/client/base.py-0>\n",
+       "    Output Netcdf File\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Desktop/chickadee/</home/sangwonl/Desktop/chickadee/venv/lib/python3.7/site-packages/birdy/client/base.py-1>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
      },
@@ -140,7 +148,7 @@
     "output = chickadee.bccaq(\n",
     "    gcm_file=gcm_file, \n",
     "    obs_file=obs_file, \n",
-    "    var=var, \n",
+    "    varname=var, \n",
     "    end_date=end_date,\n",
     "    out_file=out_file,\n",
     "    num_cores=num_cores\n",
@@ -158,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +194,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/tests/test_processes/wps_test_collect_args.py
+++ b/tests/test_processes/wps_test_collect_args.py
@@ -1,0 +1,56 @@
+from pywps import Process, LiteralInput, ComplexInput, LiteralOutput, FORMATS
+from chickadee.utils import collect_args
+import logging
+
+
+class TestCollectArgs(Process):
+    def __init__(self):
+        inputs = [
+            ComplexInput(
+                "local_file",
+                "Local file",
+                abstract="Path to the local input file",
+                supported_formats=[FORMATS.NETCDF],
+            ),
+            ComplexInput(
+                "opendap_url",
+                "OPeNDAP URL",
+                abstract="URL to the opendap input file",
+                supported_formats=[FORMATS.DODS],
+            ),
+            LiteralInput(
+                "argc",
+                "Argument count",
+                abstract="Number of input arguments",
+                data_type="integer",
+            ),
+        ]
+        outputs = [
+            LiteralOutput(
+                "collected_argc",
+                "Collected argument count",
+                abstract="Number of collected arguments",
+                data_type="integer",
+            ),
+        ]
+
+        super(TestCollectArgs, self).__init__(
+            self._handler,
+            identifier="test_collect_args",
+            title="Test collect_args",
+            abstract="A simple process that tests collect_args.",
+            inputs=inputs,
+            outputs=outputs,
+            store_supported=True,
+            status_supported=True,
+        )
+
+    @staticmethod
+    def _handler(request, response):
+        collected = collect_args(request)
+        collected_argc = len(collected)
+
+        assert collected_argc == request.inputs["argc"][0].data
+
+        response.outputs["collected_argc"].data = collected_argc
+        return response

--- a/tests/test_processes/wps_test_collect_args.py
+++ b/tests/test_processes/wps_test_collect_args.py
@@ -4,6 +4,8 @@ import logging
 
 
 class TestCollectArgs(Process):
+    """A simple wps process for test_collect_args in test_utils.py"""
+
     def __init__(self):
         inputs = [
             ComplexInput(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import pytest
+from pywps.app.exceptions import ProcessError
+from chickadee.utils import get_package, collect_args, set_end_date
+from datetime import date
+from rpy2.robjects.packages import importr
+
+base = importr("base")
+
+
+@pytest.mark.parametrize("package", ["ClimDown"])
+def test_get_pacakge(package):
+    pkg = get_package(package)
+    assert pkg.__dict__["__rname__"] == package
+
+
+@pytest.mark.parametrize("package", ["invalid_pkg"])
+def test_get_package_err(package):
+    with pytest.raises(ProcessError) as e:
+        get_package(package)
+    assert str(vars(e)["_excinfo"][1]) == f"R package, {package}, is not installed"
+
+
+@pytest.mark.parametrize("end_date", [date(1972, 12, 31), date.today()])
+def test_set_r_options(end_date):
+    set_end_date(end_date)
+    assert str(base.getOption("calibration.end")).split('"')[1].split()[0] == str(
+        end_date
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,11 @@
 import pytest
 from pywps.app.exceptions import ProcessError
+from pkg_resources import resource_filename
 from chickadee.utils import get_package, collect_args, set_end_date
 from datetime import date
 from rpy2.robjects.packages import importr
+from wps_tools.testing import run_wps_process
+from .test_processes.wps_test_collect_args import TestCollectArgs
 
 base = importr("base")
 
@@ -26,3 +29,22 @@ def test_set_r_options(end_date):
     assert str(base.getOption("calibration.end")).split('"')[1].split()[0] == str(
         end_date
     )
+
+
+@pytest.mark.parametrize(
+    ("local_file", "opendap_url", "argc"),
+    [
+        (
+            f"file://{resource_filename(__name__, 'data/tiny_gcm.nc')}",
+            "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets/storage/data/projects/comp_support/daccs/chickadee/tests/data/tiny_obs.nc",
+            3,
+        )
+    ],
+)
+def test_collect_args(local_file, opendap_url, argc):
+    params = (
+        f"local_file=@xlink:href={local_file};"
+        f"opendap_url=@xlink:href={opendap_url};"
+        f"argc={argc};"
+    )
+    run_wps_process(TestCollectArgs(), params)

--- a/tests/test_wps_QDM.py
+++ b/tests/test_wps_QDM.py
@@ -1,0 +1,34 @@
+import pytest
+from pkg_resources import resource_filename
+from tempfile import NamedTemporaryFile
+from datetime import date
+
+from wps_tools.testing import run_wps_process
+from chickadee.processes.wps_QDM import QDM
+
+
+@pytest.mark.parametrize(
+    ("gcm_file", "obs_file", "var", "end_date", "num_cores"),
+    [
+        (
+            f"file://{resource_filename(__name__, 'data/tiny_obs.nc')}",
+            f"file://{resource_filename(__name__, 'data/CI_expected_output.nc')}",
+            "tasmax",
+            date(1972, 12, 31),
+            4,
+        ),
+    ],
+)
+def test_wps_QDM(obs_file, gcm_file, var, end_date, num_cores):
+    with NamedTemporaryFile(
+        suffix=".nc", prefix="output_", dir="/tmp", delete=True
+    ) as out_file:
+        datainputs = (
+            f"obs_file=@xlink:href={obs_file};"
+            f"gcm_file=@xlink:href={gcm_file};"
+            f"varname={var};"
+            f"out_file={out_file.name};"
+            f"num_cores={num_cores};"
+            f"end_date={end_date};"
+        )
+        run_wps_process(QDM(), datainputs)

--- a/tests/test_wps_caps.py
+++ b/tests/test_wps_caps.py
@@ -13,4 +13,5 @@ def test_wps_caps():
     assert sorted(names.split()) == [
         "bccaq",
         "ci",
+        "qdm",
     ]


### PR DESCRIPTION
resolves #12 

The wrapper function for ClimDown's qdm.netcdf.wrapper, named `wps_QDM`, is implemented. The Docker container is up in port 30125 and can be tested by running `make test-notebooks-custom`. Some changes were made in `wps_bccaq.py` and `wps_bccaq_demo.ipynb` to adapt the modified `collect_common_args` in `utils.py`