### PR TITLE
Multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,20 @@ COPY requirements.txt r_requirements.txt install_pkgs.R ./
 # Install python and R packages
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
+    # Install pip
     python3-pip \
+    # Install libraries for R packages installation
     libssl-dev \
     libxml2-dev \
     libudunits2-dev \
     libnetcdf-dev \
     libgit2-dev && \
+    # Install R packages
     Rscript install_pkgs.R r_requirements.txt && \
+    # Install python packages
     pip3 install --upgrade pip && \
     pip3 install -r requirements.txt --ignore-installed --user && \
+    # Install gunicorn
     pip3 install gunicorn --user
 
 FROM rocker/r-ver:4.0.3 AS prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && \
 COPY --from=builder /root/.local /root/.local
 
 # Copy compiled library files
+# Necessary files are found manually by running processes
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libnetcdf.so.15 \
   /usr/lib/x86_64-linux-gnu/libhdf5_serial_hl.so.100 \
   /usr/lib/x86_64-linux-gnu/libhdf5_serial.so.103 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,83 @@
-FROM r-base:4.0.3
-
-MAINTAINER https://github.com/pacificclimate/chickadee
-LABEL Description="chickadee WPS" Vendor="Birdhouse" Version="0.1.0"
+FROM r-base:4.0.3 AS builder
 
 ENV PIP_INDEX_URL="https://pypi.pacificclimate.org/simple/"
-
-WORKDIR /code
 
 COPY requirements.txt r_requirements.txt install_pkgs.R ./
 
 # Install python and R packages
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      build-essential \
-      gcc \
-      libgit2-dev \
-      libpq-dev \
-      python3.8 \
-      python3-pip \
-      python3-setuptools \
-      python3-dev \
-      libssl-dev \
-      libxml2-dev \
-      libudunits2-dev \
-      libnetcdf-dev && \
+  apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    libpq-dev \
+    python3.8 \
+    python3-pip \
+    python3-setuptools \
+    python3-dev \
+    libssl-dev \
+    libxml2-dev \
+    libudunits2-dev \
+    libnetcdf-dev \
+    libgit2-dev && \
+    Rscript install_pkgs.R r_requirements.txt && \
     pip3 install --upgrade pip && \
-    pip3 install -r requirements.txt --ignore-installed && \
-    pip3 install gunicorn && \
-    Rscript install_pkgs.R r_requirements.txt
+    pip3 install -r requirements.txt --ignore-installed --user && \
+    pip3 install gunicorn --user
+
+FROM r-base:4.0.3 AS prod
+MAINTAINER https://github.com/pacificclimate/chickadee
+LABEL Description="chickadee WPS" Vendor="Birdhouse" Version="0.1.0"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      python3.8 \
+      python3-pip
+
+COPY --from=builder /root/.local /root/.local
+
+# Copy compiled library files
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libnetcdf.so.18 \
+  /usr/lib/x86_64-linux-gnu/libhdf5_serial_hl.so.100 \
+  /usr/lib/x86_64-linux-gnu/libhdf5_serial.so.103 \
+  /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4 \
+  /usr/lib/x86_64-linux-gnu/libsz.so.2 \
+  /usr/lib/x86_64-linux-gnu/libaec.so.0 \
+  /usr/lib/x86_64-linux-gnu/libudunits2.so.0 \
+  /usr/lib/x86_64-linux-gnu/
+
+# Copy R packages
+# Directories cannot be recursively copied
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/PCICt \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/PCICt
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/udunits2 \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/udunits2
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/ncdf4 \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/ncdf4
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/fields \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/fields
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/foreach \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/foreach
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/seas \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/seas
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/abind \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/abind
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/ClimDown \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/ClimDown
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/doParallel \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/doParallel
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/maps \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/maps
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/spam \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/spam
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/dotCall64 \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/dotCall64
+COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/iterators \
+  /root/R/x86_64-pc-linux-gnu-library/4.0/iterators
+
+# Make sure scripts in .local are usable:
+ENV PATH=/root/.local/bin:$PATH
+
+WORKDIR /code
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libnetcdf.so.15 \
   /usr/lib/x86_64-linux-gnu/libudunits2.so.0 \
   /usr/lib/x86_64-linux-gnu/
 
-# Copy R packages
+# Copy R packages in r_requirements.txt and their dependencies
 # Directories cannot be recursively copied
 COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/PCICt \
   /root/R/x86_64-pc-linux-gnu-library/4.0/PCICt

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ ENV LD_LIBRARY_PATH=/usr/local/lib/R/lib:$LD_LIBRARY_PATH
 
 WORKDIR /code
 
-COPY . .
+COPY ./chickadee /code/chickadee
 
 EXPOSE 5004
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,13 @@ FROM rocker/r-ver:4.0.3 AS prod
 MAINTAINER https://github.com/pacificclimate/chickadee
 LABEL Description="chickadee WPS" Vendor="pacificclimate" Version="1.0.2"
 
+# Install Python
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       python3.8 \
       python3-pip
 
+# COPY Python packages from builder
 COPY --from=builder /root/.local /root/.local
 
 # Copy compiled library files
@@ -74,7 +76,7 @@ COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/dotCall64 \
 COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/iterators \
   /root/R/x86_64-pc-linux-gnu-library/4.0/iterators
 
-# Make sure scripts in .local are usable:
+# Make sure scripts in .local are usable
 ENV PATH=/root/.local/bin:$PATH
 # Add path to libR.so to the environment variable LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH=/usr/local/lib/R/lib:$LD_LIBRARY_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/iterators \
 
 # Make sure scripts in .local are usable:
 ENV PATH=/root/.local/bin:$PATH
+# Add path to libR.so to the environment variable LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH=/usr/local/lib/R/lib:$LD_LIBRARY_PATH
 
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,7 @@ COPY requirements.txt r_requirements.txt install_pkgs.R ./
 # Install python and R packages
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
-    build-essential \
-    gcc \
-    libpq-dev \
-    python3.8 \
     python3-pip \
-    python3-setuptools \
-    python3-dev \
     libssl-dev \
     libxml2-dev \
     libudunits2-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM r-base:4.0.3 AS builder
+FROM rocker/r-ver:4.0.3 AS builder
 
 ENV PIP_INDEX_URL="https://pypi.pacificclimate.org/simple/"
 
@@ -24,7 +24,7 @@ RUN apt-get update && \
     pip3 install -r requirements.txt --ignore-installed --user && \
     pip3 install gunicorn --user
 
-FROM r-base:4.0.3 AS prod
+FROM rocker/r-ver:4.0.3 AS prod
 MAINTAINER https://github.com/pacificclimate/chickadee
 LABEL Description="chickadee WPS" Vendor="Birdhouse" Version="0.1.0"
 
@@ -36,7 +36,7 @@ RUN apt-get update && \
 COPY --from=builder /root/.local /root/.local
 
 # Copy compiled library files
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libnetcdf.so.18 \
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libnetcdf.so.15 \
   /usr/lib/x86_64-linux-gnu/libhdf5_serial_hl.so.100 \
   /usr/lib/x86_64-linux-gnu/libhdf5_serial.so.103 \
   /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4 \
@@ -76,6 +76,7 @@ COPY --from=builder /root/R/x86_64-pc-linux-gnu-library/4.0/iterators \
 
 # Make sure scripts in .local are usable:
 ENV PATH=/root/.local/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/lib/R/lib:$LD_LIBRARY_PATH
 
 WORKDIR /code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
 
 FROM rocker/r-ver:4.0.3 AS prod
 MAINTAINER https://github.com/pacificclimate/chickadee
-LABEL Description="chickadee WPS" Vendor="Birdhouse" Version="0.1.0"
+LABEL Description="chickadee WPS" Vendor="pacificclimate" Version="1.0.2"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
resolves #42 

The multi-stage build reduced the final image size to 1.03GB with an intermediate image size of 1.5GB
```
[sangwonl@docker-dev03 chickadee]$ docker images | grep chickadee
pcic/chickadee              multi-stage        edb02a049be7   17 minutes ago   1.03GB
pcic/chickadee              0.4.0              a8543c993480   3 weeks ago      2.55GB
```
`rocker` base image is used to reduce the image sizes. The intermediate image caching will also reduce the build time and speed up the development significantly.

Test port: 30126