### PR TITLE
Use asobj=True for netcdf outputs

### DIFF
--- a/notebooks/wps_BCCAQ_demo.ipynb
+++ b/notebooks/wps_BCCAQ_demo.ipynb
@@ -111,6 +111,7 @@
        "\u001b[0;34m\u001b[0m    \u001b[0mtasmax_ratio\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mtasmin_ratio\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mout_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0moutput_formats\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Full statistical downscaling of coarse scale global climate model (GCM) output to a fine spatial resolution\n",
@@ -212,79 +213,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out_file = NamedTemporaryFile(suffix=\".nc\", prefix=\"output_\", dir=\"/tmp\", delete=True)\n",
-    "\n",
-    "output = chickadee.bccaq(\n",
-    "    gcm_file=resource_filename(\"tests\", \"/data/tiny_gcm.nc\"), \n",
-    "    obs_file=resource_filename(\"tests\", \"/data/tiny_obs.nc\"), \n",
-    "    varname=\"tasmax\", \n",
-    "    end_date=date(1972, 12, 31),\n",
-    "    out_file=out_file.name,\n",
-    "    num_cores=4\n",
-    ")\n",
-    "\n",
-    "out_file.close()\n",
-    "\n",
-    "output_data = output.get()[0]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Access the output with nc_to_dataset() or auto_construct_outputs() from wps_tools.output_handling"
+    "with NamedTemporaryFile(\n",
+    "    suffix=\".nc\", prefix=\"output_\", dir=\"/tmp\", delete=True\n",
+    ") as out_file:\n",
+    "    output = chickadee.bccaq(\n",
+    "        gcm_file=resource_filename(\"tests\", \"/data/tiny_gcm.nc\"), \n",
+    "        obs_file=resource_filename(\"tests\", \"/data/tiny_obs.nc\"), \n",
+    "        varname=\"tasmax\", \n",
+    "        end_date=date(1972, 12, 31),\n",
+    "        out_file=out_file.name,\n",
+    "        num_cores=4\n",
+    "    )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<class 'netCDF4._netCDF4.Dataset'>\n",
-       "root group (NETCDF3_CLASSIC data model, file format NETCDF3):\n",
-       "    dimensions(sizes): lon(26), lat(26), time(3651)\n",
-       "    variables(dimensions): float64 lon(lon), float64 lat(lat), float64 time(time), float32 tasmax(time,lat,lon)\n",
-       "    groups: "
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "from wps_tools.output_handling import nc_to_dataset, auto_construct_outputs\n",
-    "\n",
-    "output_dataset = nc_to_dataset(output_data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<class 'netCDF4._netCDF4.Dataset'>\n",
-       " root group (NETCDF3_CLASSIC data model, file format NETCDF3):\n",
-       "     dimensions(sizes): lon(26), lat(26), time(3651)\n",
-       "     variables(dimensions): float64 lon(lon), float64 lat(lat), float64 time(time), float32 tasmax(time,lat,lon)\n",
-       "     groups: ]"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "auto_construct_outputs(output.get())"
+    "# Use asobj=True to access the output file contents as a dataset\n",
+    "output_dataset = output.get(asobj=True)[0]"
    ]
   },
   {
@@ -296,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/wps_CA_demo.ipynb
+++ b/notebooks/wps_CA_demo.ipynb
@@ -26,6 +26,8 @@
     "from urllib.request import urlopen\n",
     "import requests\n",
     "import os\n",
+    "\n",
+    "from wps_tools.output_handling import rda_to_vector, auto_construct_outputs\n",
     "from chickadee.utils import test_analogues\n",
     "\n",
     "# Ensure we are in the working directory with access to the data\n",
@@ -97,6 +99,7 @@
        "\u001b[0;34m\u001b[0m    \u001b[0mtol\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0.1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0moutput_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'output.rda'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mvector_name\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'output_vector'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0moutput_formats\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Constructed Analogue (CA) downscaling algorithm\n",
@@ -183,7 +186,6 @@
     "        output_file=output_file.name,\n",
     "        vector_name=\"analogues_output\"\n",
     "    )\n",
-    "\n",
     "url = output.get()[0]"
    ]
   },
@@ -212,7 +214,7 @@
        "            indices\n",
        "            </th>\n",
        "            <td>\n",
-       "            <rpy2.rinterface.ListSexpVector object at 0x7fa5d6763080> [RTYPES.VECSXP]\n",
+       "            <rpy2.rinterface.ListSexpVector object at 0x7fd213d08300> [RTYPES.VECSXP]\n",
        "            </td>\n",
        "          </tr>\n",
        "        \n",
@@ -221,7 +223,7 @@
        "            weights\n",
        "            </th>\n",
        "            <td>\n",
-       "            <rpy2.rinterface.ListSexpVector object at 0x7fa5d6763100> [RTYPES.VECSXP]\n",
+       "            <rpy2.rinterface.ListSexpVector object at 0x7fd213d08d80> [RTYPES.VECSXP]\n",
        "            </td>\n",
        "          </tr>\n",
        "        \n",
@@ -233,9 +235,9 @@
        "R object with classes: ('list',) mapped to:\n",
        "[ListSexpVector, ListSexpVector]\n",
        "  indices: <class 'rpy2.rinterface.ListSexpVector'>\n",
-       "  <rpy2.rinterface.ListSexpVector object at 0x7fa5d675bbc0> [RTYPES.VECSXP]\n",
+       "  <rpy2.rinterface.ListSexpVector object at 0x7fd2145d5d80> [RTYPES.VECSXP]\n",
        "  weights: <class 'rpy2.rinterface.ListSexpVector'>\n",
-       "  <rpy2.rinterface.ListSexpVector object at 0x7fa5d675bd80> [RTYPES.VECSXP]"
+       "  <rpy2.rinterface.ListSexpVector object at 0x7fd213d0a0c0> [RTYPES.VECSXP]"
       ]
      },
      "execution_count": 6,
@@ -245,8 +247,6 @@
    ],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
-    "from wps_tools.output_handling import rda_to_vector, auto_construct_outputs\n",
-    "\n",
     "rda_to_vector(url, \"analogues_output\")"
    ]
   },
@@ -261,9 +261,9 @@
        "[R object with classes: ('list',) mapped to:\n",
        " [ListSexpVector, ListSexpVector]\n",
        "   indices: <class 'rpy2.rinterface.ListSexpVector'>\n",
-       "   <rpy2.rinterface.ListSexpVector object at 0x7fa5d6763c40> [RTYPES.VECSXP]\n",
+       "   <rpy2.rinterface.ListSexpVector object at 0x7fd213cb43c0> [RTYPES.VECSXP]\n",
        "   weights: <class 'rpy2.rinterface.ListSexpVector'>\n",
-       "   <rpy2.rinterface.ListSexpVector object at 0x7fa5d6768400> [RTYPES.VECSXP]]"
+       "   <rpy2.rinterface.ListSexpVector object at 0x7fd213cc6040> [RTYPES.VECSXP]]"
       ]
      },
      "execution_count": 7,

--- a/notebooks/wps_CI_demo.ipynb
+++ b/notebooks/wps_CI_demo.ipynb
@@ -86,6 +86,7 @@
        "\u001b[0;34m\u001b[0m    \u001b[0mstart_date\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdatetime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m1971\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mend_date\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdatetime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m2005\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m12\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m31\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mout_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0moutput_formats\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Climate Imprint (CI) downscaling\n",
@@ -157,67 +158,9 @@
     "        obs_file = resource_filename(\"tests\", \"/data/tiny_obs.nc\"),\n",
     "        out_file = out_file.name,\n",
     "        varname = \"tasmax\",\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Access the output with nc_to_dataset() or auto_construct_outputs() from wps_tools.output_handling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<class 'netCDF4._netCDF4.Dataset'>\n",
-       "root group (NETCDF3_CLASSIC data model, file format NETCDF3):\n",
-       "    dimensions(sizes): lon(26), lat(26), time(3651)\n",
-       "    variables(dimensions): float64 lon(lon), float64 lat(lat), float64 time(time), float32 tasmax(time,lat,lon)\n",
-       "    groups: "
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "from wps_tools.output_handling import nc_to_dataset, auto_construct_outputs\n",
-    "\n",
-    "output_dataset = nc_to_dataset(output.get()[0])\n",
-    "output_dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<class 'netCDF4._netCDF4.Dataset'>\n",
-       " root group (NETCDF3_CLASSIC data model, file format NETCDF3):\n",
-       "     dimensions(sizes): lon(26), lat(26), time(3651)\n",
-       "     variables(dimensions): float64 lon(lon), float64 lat(lat), float64 time(time), float32 tasmax(time,lat,lon)\n",
-       "     groups: ]"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "auto_construct_outputs(output.get())"
+    "    )\n",
+    "# Use asobj=True to access the output file contents as a dataset\n",
+    "output_dataset = output.get(asobj=True)[0]"
    ]
   },
   {
@@ -229,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/wps_QDM_demo.ipynb
+++ b/notebooks/wps_QDM_demo.ipynb
@@ -101,6 +101,7 @@
        "\u001b[0;34m\u001b[0m    \u001b[0mtasmax_ratio\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mtasmin_ratio\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mout_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0moutput_formats\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "High-level wrapper for Quantile Delta Mapping (QDM)\n",
@@ -201,67 +202,9 @@
     "        out_file = out_file.name,\n",
     "        varname = \"tasmax\",\n",
     "        num_cores = 2\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Access the output with nc_to_dataset() or auto_construct_outputs() from wps_tools.output_handling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<class 'netCDF4._netCDF4.Dataset'>\n",
-       "root group (NETCDF3_CLASSIC data model, file format NETCDF3):\n",
-       "    dimensions(sizes): lon(26), lat(26), time(3651)\n",
-       "    variables(dimensions): float64 lon(lon), float64 lat(lat), float64 time(time), float32 tasmax(time,lat,lon)\n",
-       "    groups: "
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "from wps_tools.output_handling import nc_to_dataset, auto_construct_outputs\n",
-    "\n",
-    "output_dataset = nc_to_dataset(output.get()[0])\n",
-    "output_dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<class 'netCDF4._netCDF4.Dataset'>\n",
-       " root group (NETCDF3_CLASSIC data model, file format NETCDF3):\n",
-       "     dimensions(sizes): lon(26), lat(26), time(3651)\n",
-       "     variables(dimensions): float64 lon(lon), float64 lat(lat), float64 time(time), float32 tasmax(time,lat,lon)\n",
-       "     groups: ]"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "auto_construct_outputs(output.get())"
+    "    )\n",
+    "# Use asobj=True to access the output file contents as a dataset\n",
+    "output_dataset = output.get(asobj=True)[0]"
    ]
   },
   {
@@ -273,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/wps_rerank_demo.ipynb
+++ b/notebooks/wps_rerank_demo.ipynb
@@ -20,7 +20,6 @@
     "from birdy import WPSClient\n",
     "from netCDF4 import Dataset\n",
     "from pkg_resources import resource_filename\n",
-    "from wps_tools.output_handling import nc_to_dataset, auto_construct_outputs\n",
     "from wps_tools.testing import get_target_url\n",
     "from tempfile import NamedTemporaryFile\n",
     "import requests\n",
@@ -171,7 +170,8 @@
     "        num_cores=2,\n",
     "        analogues_object=resource_filename(\"tests\", \"data/analogues.rda\")\n",
     "    )\n",
-    "output_data_rda = output.get()[0]"
+    "# Use asobj=True to access the output file contents as a dataset\n",
+    "output_dataset_rda = output.get(asobj=True)[0]"
    ]
   },
   {
@@ -196,49 +196,7 @@
     "        num_cores=2,\n",
     "        analogues_object=resource_filename(\"tests\", \"data/analogues.rds\")\n",
     "    )\n",
-    "output_data_rds = output.get()[0]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Access the output with nc_to_dataset() or auto_construct_outputs() from wps_tools.output_handling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "output_dataset_rda = nc_to_dataset(output_data_rda)\n",
-    "output_dataset_rds = nc_to_dataset(output_data_rds)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<class 'netCDF4._netCDF4.Dataset'>\n",
-       " root group (NETCDF3_CLASSIC data model, file format NETCDF3):\n",
-       "     dimensions(sizes): lon(26), lat(26), time(3651)\n",
-       "     variables(dimensions): float64 lon(lon), float64 lat(lat), float64 time(time), float32 tasmax(time, lat, lon)\n",
-       "     groups: ]"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "auto_construct_outputs(output.get())"
+    "output_dataset_rds = output.get(asobj=True)[0]"
    ]
   },
   {
@@ -250,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Resolves #54 
- Replace `wps_tools.output_handling.nc_to_dataset()` with `output.get(asobj=True)`
- `asobj=True` does not work for `rdata` files (just returns the bytes)

Test on port `30253`