### PR TITLE
I65 resolve dependency

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ ipython
 pytest-notebook
 nbsphinx
 nbval>=0.9.6
-nbconvert~=5.6.0
+nbconvert>=6.4.4
 sphinx==2.4.4
 bumpversion
 twine

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, "README.md")).read()
 CHANGES = open(os.path.join(here, "CHANGES.md")).read()
-REQUIRES_PYTHON = ">=3.5.0"
+REQUIRES_PYTHON = ">=3.7.0"
 
 about = {}
 with open(os.path.join(here, "chickadee", "__version__.py"), "r") as f:
@@ -28,9 +28,8 @@ classifiers = [
     "Programming Language :: Python",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Scientific/Engineering :: Atmospheric Science",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]


### PR DESCRIPTION
This PR resolves #65. In doing so, `nbconvert` has been pinned to `>=6.4.4`, and support for Python 3.6 has been dropped.